### PR TITLE
use :exists instead of deprecated .exists

### DIFF
--- a/lib/HTTP/Status.pm6
+++ b/lib/HTTP/Status.pm6
@@ -79,7 +79,7 @@ my %HTTPCODES = {
 };
 
 our sub get_http_status_msg ($code) is export {
-  if %HTTPCODES.exists($code) {
+  if %HTTPCODES{$code}:exists {
     return %HTTPCODES{$code};
   }
   return 'Unknown';


### PR DESCRIPTION
In advance of upcoming star release, trying to avoid any current deprecation notices.
