### PR TITLE
{ a => 1 } is an itemized hash, and is not meant to flatten

### DIFF
--- a/lib/HTTP/Status.pm6
+++ b/lib/HTTP/Status.pm6
@@ -6,7 +6,7 @@ module HTTP::Status;
 ## Returns the plain text message that belongs to that code.
 ## Info from http://en.wikipedia.org/wiki/Http_status_codes
 
-my %HTTPCODES = {
+my %HTTPCODES = (
   ## 1xx Informational
   100 => 'Continue',
   101 => 'Switching Protocols',
@@ -76,7 +76,7 @@ my %HTTPCODES = {
   598 => 'Network Read Timeout Error',
   599 => 'Network Connect Timeout Error',
   ## End of defined codes.
-};
+);
 
 our sub get_http_status_msg ($code) is export {
   if %HTTPCODES{$code}:exists {


### PR DESCRIPTION
The flattening behaviour is deprecated, and it will result in an one-element hash assignment (failure) in future. I replaced the curlies by parens, even when they are not needed the code looks less odd.
