### PR TITLE
the hash key is a string, so make it one for the lookup

### DIFF
--- a/lib/HTTP/Status.pm6
+++ b/lib/HTTP/Status.pm6
@@ -79,8 +79,8 @@ my %HTTPCODES = (
 );
 
 our sub get_http_status_msg ($code) is export {
-  if %HTTPCODES{$code}:exists {
-    return %HTTPCODES{$code};
+  if %HTTPCODES{~$code}:exists {
+    return %HTTPCODES{~$code};
   }
   return 'Unknown';
 }


### PR DESCRIPTION
This unbreaks HTTP::Status on parrot.
