### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/HTTP/Status.pm6
+++ b/lib/HTTP/Status.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module HTTP::Status;
+unit module HTTP::Status;
 
 ## Exports a function get_http_status_msg($code)
 ## Returns the plain text message that belongs to that code.


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.