### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl6
 use v6;
 
-#BEGIN { @*INC.unshift: './lib'; }
+#use lib 'lib';
 
 use HTTP::Status;
 use Test;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.